### PR TITLE
NO-TICK: Simplifying machine to one model and reducing core count.

### DIFF
--- a/node-operator/hardware.rst
+++ b/node-operator/hardware.rst
@@ -5,9 +5,11 @@ Recommended Hardware Specifications
 System Requirements
 -------------------
 
+MainNet and TestNet
 
-* Production - 8 Cores, 32 GB Ram, 2 TB disk
-* Testnet - 4 Cores, 16 GB Ram, 1 TB disk
+ * 4 Cores
+ * 32 GB Ram
+ * 2 TB disk
 
 Linux machine running Ubuntu 18.04 or 20.04 with a Rust build environment.
 Reference `https://github.com/Casperlabs/casper-node <https://github.com/Casperlabs/casper-node>`_ for details.


### PR DESCRIPTION
Reduced core counts to 4 and changed to 1 configuration for both nets per Ed.