### PR TITLE
minor fixes

### DIFF
--- a/dapp-dev-guide/writing-contracts/writing-rust-contracts.rst
+++ b/dapp-dev-guide/writing-contracts/writing-rust-contracts.rst
@@ -34,7 +34,7 @@ To leverage this feature, use `runtime::get_named_arg <https://docs.rs/casper-co
 Storage
 ^^^^^^^
 
-Saving and reading values to and from the blockchain is a manual process in Casper. It requires more code to be written, but also provides a lot of flexibility. The storage system works similarly to a file system in an operating system.  Let's say we have a string ``"Hello Casper!"`` that needs to be saved. To do this, use the text editor, create a new file, paste the string in and save it under a name in some directory. The pattern is similar on the Casper blockchain. First you have to save your value to the memory using `storage::new_turef <https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.new_turef.html>`_. This returns a reference to the memory object that holds the ``"Hello Casper!"`` value. You could use this reference to update the value to something else. It's like a file. Secondly you have to save the reference under a human-readable string using `runtime::put_key <https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html>`_. It's like giving a name to the file. The following function implements this scenario:
+Saving and reading values to and from the blockchain is a manual process in Casper. It requires more code to be written, but also provides a lot of flexibility. The storage system works similarly to a file system in an operating system.  Let's say we have a string ``"Hello Casper!"`` that needs to be saved. To do this, use the text editor, create a new file, paste the string in and save it under a name in some directory. The pattern is similar on the Casper blockchain. First you have to save your value to the memory using `storage::new_uref <https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.new_uref.html>`_. This returns a reference to the memory object that holds the ``"Hello Casper!"`` value. You could use this reference to update the value to something else. It's like a file. Secondly you have to save the reference under a human-readable string using `runtime::put_key <https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html>`_. It's like giving a name to the file. The following function implements this scenario:
 
 .. code-block:: rust
 
@@ -42,7 +42,7 @@ Saving and reading values to and from the blockchain is a manual process in Casp
 
    fn store(value: String) {
        // Store `value` under a new unforgeable reference.
-       let value_ref = storage::new_turef(value);
+       let value_ref = storage::new_uref(value);
 
        // Wrap the unforgeable reference in a `Key`.
        let value_key: Key = value_ref.into();

--- a/implementation/p2p.rst
+++ b/implementation/p2p.rst
@@ -303,7 +303,7 @@ following parameters:
 -  ``target_block_hashes`` is typically the hashes of the new Blocks the node was
    notified about, but if multiple iterations are needed to find the connection
    points then they can be further back the DAG.
--  ``known_block_hashes`` can be supplied by the caller to provide an early exist
+-  ``known_block_hashes`` can be supplied by the caller to provide an early exit
    criteria for the traversal. These can, for example, include the hashes close to
    the tip of the callers DAG, forks, last Blocks seen from validators, and
    approved Blocks (i.e., Blocks with a high safety threshold).
@@ -312,7 +312,7 @@ following parameters:
    iterations when we have to go back *beyond* the callers approved blocks, in
    which case it might be difficult to pick known hashes.
 
-The result should be a partial traversal of the DAG in *reverse BFS order*
+The result should be a partial traversal of the DAG in *reverse breadth-first search order*
 returning a stream of ``BlockSummaries`` that the caller can partially verify,
 merge into its DAG of pending Blocks, then recursively call
 ``StreamAncestorBlockSummaries`` on any Block that didn’t connect with a known
@@ -562,7 +562,7 @@ brevity but they do the same thing as the ones on the left side.
 
 
 Deploy Gossiping
----------------
+----------------
 
 With certain consensus protocols, nodes can only produce blocks when its their turn to do so.
 To make sure that users can send their deploys to any node and see them included in the next


### PR DESCRIPTION
This PR fixes minor issues in the docs. 

1. Remove turef from the docs. It should be storage::new_uref as per the crate documentation.
2. Mistakes brought up by Broadleaf in https://docs.casperlabs.io/en/latest/implementation/p2p.html?highlight=bfs#streamancestorblocksummaries
- "early exist criteria" should be early "exit" criteria
- "BFS" stands for "breadth-first search"

