### PR TITLE
ECO-938: new top menu

### DIFF
--- a/dapp-dev-guide/index.rst
+++ b/dapp-dev-guide/index.rst
@@ -1,5 +1,5 @@
-Developer Guide
-====================
+Developers
+==========
 
 This guide is designed to support developers getting started with the development of smart contracts on the Casper blockchain in AssemblyScript or Rust. For Rust, there is a contract development kit that includes a runtime environment, reference documentation, and test framework. You can install our environment locally, create and test Smart Contracts with our Smart Contracts and Test Libraries, and use these libraries to build your own applications.
 

--- a/implementation/index.rst
+++ b/implementation/index.rst
@@ -1,5 +1,5 @@
-Blockchain Design
-=================
+Design
+======
 
 .. toctree::
    :maxdepth: 2

--- a/index.rst
+++ b/index.rst
@@ -32,7 +32,6 @@ and our token policies.
    :maxdepth: 3
    :titlesonly:
 
-   Home <self>
    implementation/index
    economics/index
    staking/index

--- a/node-operator/index.rst
+++ b/node-operator/index.rst
@@ -1,5 +1,5 @@
-Node Operator Guide
-===================
+Operators
+=========
 
 Operators that wish to run node infrastructure on the Casper network, either as a standalone private network, or as part of the public network should explore this guide.
 

--- a/staking/index.rst
+++ b/staking/index.rst
@@ -2,7 +2,7 @@
    :format: html
 
 =======
-Staking on Casper
+Staking
 =======
 
 A feature of Proof-of-Stake protocols is that token holders can actively participate in the protocol 

--- a/staking/index.rst
+++ b/staking/index.rst
@@ -1,6 +1,7 @@
 .. role:: raw-html-m2r(raw)
    :format: html
 
+=======
 Staking on Casper
 =======
 


### PR DESCRIPTION
The extra space in the top menu bar (after staking) was fixed with George's help; and, I simplified the top menu bar.
- commit 1: fixed the extra space
- commit 2: simplified the top menu 

Adding a few reviewers based on who has more time. Thank you :).

Commit 1:
<img width="1440" alt="Screenshot_2021-03-06_at_23_47_04" src="https://user-images.githubusercontent.com/4185994/110224266-49240600-7eda-11eb-9455-ca931450c9b4.png">
<img width="1440" alt="Screenshot_2021-03-06_at_23_47_13" src="https://user-images.githubusercontent.com/4185994/110224268-4a553300-7eda-11eb-98b8-ae0807b59bce.png">

Commit 2:
<img width="1204" alt="Screenshot_2021-03-07_at_00_00_06" src="https://user-images.githubusercontent.com/4185994/110224274-54773180-7eda-11eb-990b-dc5fc3c585a7.png">
<img width="1254" alt="Screenshot_2021-03-07_at_00_00_29" src="https://user-images.githubusercontent.com/4185994/110224276-550fc800-7eda-11eb-9f0a-8114fad78f3f.png">
