### PR TITLE
ECO-987: Update Global State Documentation

### DIFF
--- a/implementation/block-structure.rst
+++ b/implementation/block-structure.rst
@@ -8,7 +8,7 @@ Block Structure
 Introduction
 ------------
 
-A *block* is the primary data structure by which information about the state of the CasperLabs system is communicated between nodes of the network. We briefly describe here the format of this data structure.
+A *block* is the primary data structure by which network nodes communicate information about the state of the Casper Network. We briefly describe here the format of this data structure.
 
 .. _block-structure-proto:
 
@@ -30,7 +30,7 @@ A block consists of the following:
 -  a header
 -  a body
 
-Each of these are detailed in the subsequent sections.
+Each of these fields is detailed in the subsequent sections.
 
 ``block_hash``
 ~~~~~~~~~~~~~~
@@ -44,16 +44,16 @@ The block header contains the following fields:
 
 -  ``parent_hashes``
 
-   -  a list of ``block_hash``\ s giving the parents of the block
+   -  a list of ``block_hash``\ es giving the parents of the block
 
 -  justifications
 
-   -  a list of ``block_hash``\ s givin the justifications of the block (see consensus
+   -  a list of ``block_hash``\ es giving the justifications of the block (see consensus
       description in part A for more details)
 
 -  a summary of the global state, including
 
-   -  the :ref:`root hash of the global state trie <global-state-trie>` prior to executing
+   -  the :ref:`root hash of the global state trie <global-state-trie>` before executing
       the deploys in this block (``pre_state_hash``)
    -  the root hash of the global state trie after executing the deploys in this
       block (``post_state_hash``)
@@ -64,19 +64,16 @@ The block header contains the following fields:
 -  the time the block was created
 -  the protocol version the block was executed with
 -  the number of deploys in the block
--  the human-readable name corresponding to this instance of the CasperLabs
-   system (``chain_id``)
--  an indicator for whether this message is intended as a true block, or merely a *ballot* (see consensus description in part A for more details)
-
+-  the human-readable name corresponding to this instance of the Casper Network (``chain_id``)
+-  an indicator for whether this message is intended as a valid block or merely a *ballot* (see consensus description in part A for more details)
 
 Body
 ~~~~
 
-The block body contains an **ordered** list of ``DeployHashes`` which refer to deploys, and an **ordered** list of ``DeployHashes`` for native transfers (which are specialized deploys that only transfer token between accounts). All deploys, including a specialization such as native transfer, can be broadly categorized as some unit of work that when executed and committed affect change to global state :ref:`Global State<global-state-intro>`.
+The block body contains an **ordered** list of ``DeployHashes`` which refer to deploys, and an **ordered** list of ``DeployHashes`` for native transfers (which are specialized deploys that only transfer token between accounts). All deploys, including a specialization such as native transfer, can be broadly categorized as some unit of work that, when executed and committed, affect change to global state :ref:`Global State<global-state-intro>`.
 It should be noted that a valid block may contain no deploys and / or native transfers.
 
 The block body also contains the public key of the validator that proposed the block.
 
 Refer to the :ref:`Deploy Serialization Standard <serialization-standard-deploy>` for additional information on deploys and how they are serialized.
 Refer to :ref:`Block Serialization Standard <serialization-standard-block>` for how blocks are serialized.
-

--- a/implementation/block-structure.rst
+++ b/implementation/block-structure.rst
@@ -73,7 +73,9 @@ Body
 ~~~~
 
 The block body contains an **ordered** list of ``DeployHashes`` which refer to deploys, and an **ordered** list of ``DeployHashes`` for native transfers (which are specialized deploys that only transfer token between accounts). All deploys, including a specialization such as native transfer, can be broadly categorized as some unit of work that when executed and committed affect change to global state :ref:`Global State<global-state-intro>`.
-The block body also contains the public key of the validator that proposed the block. It should be noted that a valid block may contain no deploys and / or native transfers.
+It should be noted that a valid block may contain no deploys and / or native transfers.
+
+The block body also contains the public key of the validator that proposed the block.
 
 Refer to the :ref:`Deploy Serialization Standard <serialization-standard-deploy>` for additional information on deploys and how they are serialized.
 Refer to :ref:`Block Serialization Standard <serialization-standard-block>` for how blocks are serialized.

--- a/implementation/block-structure.rst
+++ b/implementation/block-structure.rst
@@ -29,7 +29,6 @@ A block consists of the following:
 -  a ``block_hash``
 -  a header
 -  a body
--  a signature
 
 Each of these are detailed in the subsequent sections.
 
@@ -74,13 +73,9 @@ The block header contains the following fields:
 Body
 ~~~~
 
-The block body contains a **ordererd** list of ``DeployHashes`` which refer to deploys, and an ordered list of ``DeployHashes`` for native transfers (which are specialized deploys that only transfer token between accounts). All deploys, including a specialization such as native transfer, can be broadly categorized as some unit of work that when executed and committed affect change to global state :ref:`Global State<global-state-intro>`.
-It should be noted that a block can be *empty* and not contain any deploys. The block body also contains the public key of the validator that proposed the block.
+The block body contains a **ordered** list of ``DeployHashes`` which refer to deploys, and an **ordered** list of ``DeployHashes`` for native transfers (which are specialized deploys that only transfer token between accounts). All deploys, including a specialization such as native transfer, can be broadly categorized as some unit of work that when executed and committed affect change to global state :ref:`Global State<global-state-intro>`.
+It should be noted that a valid block may contain no deploys and / or native transfers. The block body also contains the public key of the validator that proposed the block.
 
 Refer to the :ref:`Deploy Serialization Standard <serialization-standard-deploy>` for additional information on deploys and how they are serialized.
 Refer to :ref:`Block Serialization Standard <serialization-standard-block>` for how blocks are serialized.
 
-Signature
-~~~~~~~~~
-
-The block signature cryptographically proves the block was created by the validator who’s public key is contained in the header. The signature is created using a specified algorithm, and is signed over the ``block_hash``.

--- a/implementation/block-structure.rst
+++ b/implementation/block-structure.rst
@@ -74,17 +74,13 @@ The block header contains the following fields:
 Body
 ~~~~
 
-The block body contains a list of the deploys processed as part of this block. A processed deploy contains the following information:
+The block body contains a **ordererd** list of ``DeployHashes`` which refer to deploys. A deploy can be broadly categorized as either a transfer or some unit of work (e.g a smart contract sent to the network for execution) that changes the value of the ``state_root_hash``
+It should be noted that a block can be *empty* and not contain any deploys. The block body also contains the public key of the validator that proposed the block.
 
--  a copy of the `deploy
-   message <https://github.com/CasperLabs/CasperLabs/blob/c78e35f4d8f0f7fd9b8cf45a4b17a630ae6ab18f/protobuf/io/casperlabs/casper/consensus/consensus.proto#L24>`__
-   which was executed (see :ref:`Execution Semantics <execution-semantics-deploys>` for
-   more information about deploys and how they are executed)
--  the :ref:`amount of gas spent <execution-semantics-gas>` during its execution
--  a flag indicating whether the deploy encountered an error
--  a string for an error message (if applicable)
+Refer to the :ref:`Deploy Serialization Standard <serialization-standard-deploy>` for additional information on deploys and how they are serialized.
+Refer to :ref:`Block Serialization Standard <serialization-standard-block>` for how blocks are serialized.
 
 Signature
 ~~~~~~~~~
 
-The block signature cryptographically proves the block was created by the validator who’s public key is contained in the header. The signature is created using a specified algorithm (currently only `Ed25519 <https://en.wikipedia.org/wiki/EdDSA#Ed25519>`__ is supported), and is signed over the ``block_hash`` so that it is unique to that block.
+The block signature cryptographically proves the block was created by the validator who’s public key is contained in the header. The signature is created using a specified algorithm, and is signed over the ``block_hash``.

--- a/implementation/block-structure.rst
+++ b/implementation/block-structure.rst
@@ -74,7 +74,7 @@ The block header contains the following fields:
 Body
 ~~~~
 
-The block body contains a **ordererd** list of ``DeployHashes`` which refer to deploys. A deploy can be broadly categorized as either a transfer or some unit of work (e.g a smart contract sent to the network for execution) that affect change to :ref:`Global State<global-state-intro>`.
+The block body contains a **ordererd** list of ``DeployHashes`` which refer to deploys, and an ordered list of ``DeployHashes`` for native transfers (which are specialized deploys that only transfer token between accounts). All deploys, including a specialization such as native transfer, can be broadly categorized as some unit of work that when executed and committed affect change to global state :ref:`Global State<global-state-intro>`.
 It should be noted that a block can be *empty* and not contain any deploys. The block body also contains the public key of the validator that proposed the block.
 
 Refer to the :ref:`Deploy Serialization Standard <serialization-standard-deploy>` for additional information on deploys and how they are serialized.

--- a/implementation/block-structure.rst
+++ b/implementation/block-structure.rst
@@ -74,7 +74,7 @@ The block header contains the following fields:
 Body
 ~~~~
 
-The block body contains a **ordererd** list of ``DeployHashes`` which refer to deploys. A deploy can be broadly categorized as either a transfer or some unit of work (e.g a smart contract sent to the network for execution) that changes the value of the ``state_root_hash``
+The block body contains a **ordererd** list of ``DeployHashes`` which refer to deploys. A deploy can be broadly categorized as either a transfer or some unit of work (e.g a smart contract sent to the network for execution) that affect change to :ref:`Global State<global-state-intro>`.
 It should be noted that a block can be *empty* and not contain any deploys. The block body also contains the public key of the validator that proposed the block.
 
 Refer to the :ref:`Deploy Serialization Standard <serialization-standard-deploy>` for additional information on deploys and how they are serialized.

--- a/implementation/block-structure.rst
+++ b/implementation/block-structure.rst
@@ -66,15 +66,14 @@ The block header contains the following fields:
 -  the number of deploys in the block
 -  the human-readable name corresponding to this instance of the CasperLabs
    system (``chain_id``)
--  the public key of the validator who created this block
 -  an indicator for whether this message is intended as a true block, or merely a *ballot* (see consensus description in part A for more details)
 
 
 Body
 ~~~~
 
-The block body contains a **ordered** list of ``DeployHashes`` which refer to deploys, and an **ordered** list of ``DeployHashes`` for native transfers (which are specialized deploys that only transfer token between accounts). All deploys, including a specialization such as native transfer, can be broadly categorized as some unit of work that when executed and committed affect change to global state :ref:`Global State<global-state-intro>`.
-It should be noted that a valid block may contain no deploys and / or native transfers. The block body also contains the public key of the validator that proposed the block.
+The block body contains an **ordered** list of ``DeployHashes`` which refer to deploys, and an **ordered** list of ``DeployHashes`` for native transfers (which are specialized deploys that only transfer token between accounts). All deploys, including a specialization such as native transfer, can be broadly categorized as some unit of work that when executed and committed affect change to global state :ref:`Global State<global-state-intro>`.
+The block body also contains the public key of the validator that proposed the block. It should be noted that a valid block may contain no deploys and / or native transfers.
 
 Refer to the :ref:`Deploy Serialization Standard <serialization-standard-deploy>` for additional information on deploys and how they are serialized.
 Refer to :ref:`Block Serialization Standard <serialization-standard-block>` for how blocks are serialized.

--- a/implementation/execution-semantics.rst
+++ b/implementation/execution-semantics.rst
@@ -19,7 +19,7 @@ Measuring computational work
 Computation is all done in a `WebAssembly (wasm) <https://webassembly.org/>`__
 interpreter, allowing any programming language which compiles to wasm to become
 a smart contract language for the CasperLabs blockchain. Similar to Ethereum, we use ``Gas`` to measure computational work in a way which is consistent from node to node in the CasperLabs network. Each wasm instruction is
-`assigned <https://github.com/CasperLabs/CasperLabs/blob/1b382d5e5d2f8923c245c3844e4a6c372441c939/execution-engine/engine-wasm-prep/src/wasm_costs.rs#L9>`__
+`assigned <https://github.com/CasperLabs/casper-node/blob/cb1d20ad1ea6e245cd8237f9406885a1e785c669/execution_engine/src/shared/wasm_config.rs#L15>`_
 a ``Gas`` value, and the amount of gas spent is tracked by the runtime with each instruction executed by the interpreter. All executions are finite because each has a finite *gas limit* that specifies the maximum amount of gas that can be spent before
 the computation is terminated by the runtime. How this limit is determined is discussed in more detail below.
 
@@ -74,7 +74,7 @@ to execute deploys.
 
 Payment code ultimately provides its payment by performing a
 :ref:`token transfer <tokens-mint-interface>` into the
-`proof-of-stake contract’s payment purse <https://github.com/CasperLabs/CasperLabs/blob/1b382d5e5d2f8923c245c3844e4a6c372441c939/execution-engine/contracts/system/pos/src/lib.rs#L319>`__. If payment is not given or not enough is transferred, then payment execution is not considered successful. In this case the effects of the payment code on the
+`Handle Payment contract’s payment purse <https://github.com/CasperLabs/casper-node/blob/cb1d20ad1ea6e245cd8237f9406885a1e785c669/types/src/system/handle_payment/mod.rs#L65>`__. If payment is not given or not enough is transferred, then payment execution is not considered successful. In this case the effects of the payment code on the
 global state are reverted and the cost of the computation is covered by motes
 taken from the offending account’s main purse.
 

--- a/implementation/execution-semantics.rst
+++ b/implementation/execution-semantics.rst
@@ -144,8 +144,6 @@ description of the functions available for contracts to import, see :ref:`Append
       :ref:`URefs <uref-head>`
    -  ``new_uref`` allows creating a new ``URef`` initialized with a given value (see
       section below about how ``URef``\ s are generated)
-   -  ``read_local``, ``write_local``, ``add_local`` allow working with
-      :ref:`local keys <global-state-local-key>`
    -  ``store_function`` allows writing a contract under a :ref:`hash key <global-state-hash-key>`
    -  ``get_uref``, ``list_known_urefs``, ``add_uref``, ``remove_uref`` allow working with
       the :ref:`named keys <global-state-contracts>` of the current context

--- a/implementation/execution-semantics.rst
+++ b/implementation/execution-semantics.rst
@@ -141,7 +141,7 @@ description of the functions available for contracts to import, see :ref:`Append
 -  Reading / writing from global state
 
    -  ``read``, ``write``, ``add`` functions allow working with exiting
-      :ref:`URefs <global-state-uref>`
+      :ref:`URefs <uref-head>`
    -  ``new_uref`` allows creating a new ``URef`` initialized with a given value (see
       section below about how ``URef``\ s are generated)
    -  ``read_local``, ``write_local``, ``add_local`` allow working with

--- a/implementation/global-state.rst
+++ b/implementation/global-state.rst
@@ -11,7 +11,7 @@ Introduction
 The “global state” is the storage layer for the blockchain. All accounts,
 contracts, and any associated data they have are stored in the global state. Our
 global state has the semantics of a key-value store (with additional permissions
-logic, since not all users can access all values in the same way). Each block
+logic, since not all users can access all values in the same way). Refer to :ref:`Keys and Permissions <serialization-standard-state-keys>` for further information on keys. Each block
 causes changes to this global state because of the execution of the deploys it
 contains. In order for validators to efficiently judge the correctness of these
 changes, information about the new state needs to be communicated succinctly.
@@ -19,120 +19,6 @@ Moreover, we need to be able to communicate pieces of the global state to users,
 while allowing them to verify the correctness of the parts they receive. For
 these reasons, the key-value store is implemented as a
 :ref:`Merkle trie <global-state-trie>`.
-
-In this chapter we describe what constitutes a “key”, what constitutes a
-“value”, the permissions model for the keys, and the Merkle trie
-structure.
-
-.. _global-state-keys:
-
-Keys
-----
-
-A *key* in the global state is one of the following four data types:
-
--  32-byte account identifier (called an “account identity key”)
--  32-byte immutable contract identifier (called a “hash key”)
--  32-byte reference identifier (called an “unforgable reference”)
-
-We cover each of these key types in more detail in the sections that follow.
-
-.. _global-state-account-key:
-
-Account identity key
-~~~~~~~~~~~~~~~~~~~~
-
-This key type is used specifically for accounts in the global state. All
-accounts in the system must be stored under an account identity key, and no
-other type. The 32-byte identifier which represents this key is derived from the
-``blake2b256`` hash of the public key used to create the associated account (see
-:ref:`Accounts <accounts-associated-keys-weights>` for more information).
-
-.. _global-state-hash-key:
-
-Hash key
-~~~~~~~~
-
-This key type is used for storing contracts immutably. Once a contract is
-written under a hash key, that contract can never change. The 32-byte identifier
-representing this key is derived from the ``blake2b256`` hash of the deploy hash
-(see :ref:`block-structure-head` for more information) concatenated
-with a 4-byte sequential ID. The ID begins at zero for each deploy and
-increments by 1 each time a contract is stored. The purpose of this ID is to
-allow each contract stored in the same deploy to have a unique key.
-
-.. _global-state-uref:
-
-Unforgable Reference (``URef``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This key type is used for storing any type of value except ``Account``.
-Additionally, ``URef``\ s used in contracts carry permission information with them
-to prevent unauthorized usage of the value stored under the key. This permission
-information is tracked by the runtime, meaning that if a malicious contract
-attempts to produce a ``URef`` with permissions that contract does not actually
-have, we say the contract has attempted to “forge” the unforgable reference, and
-the runtime will raise a forged ``URef`` error. Permissions for a ``URef`` can be
-given across contract calls, allowing data stored under a ``URef`` to be shared in
-a controlled way. The 32-byte identifier representing the key is generated
-randomly by the runtime (see :ref:`Execution Semantics <execution-semantics-urefs>` for
-for more information).
-
-Refer to :ref:`Serialization format for Deploys and Values <serialization-standard-head>` on how deploys and CLValues are serialized and sent over rpc.
-
-.. _global-state-permissions:
-
-Permissions
------------
-
-There are three types of actions which can be done on a value: read, write, add.
-The reason for add to be called out separately from write is to allow for
-commutativity checking. The available actions depends on the key type and the
-context. This is summarized in the table below:
-
-+-----------------------------------+-----------------------------------+
-| Key Type                          | Available Actions                 |
-+===================================+===================================+
-| Account                           | Read + Add if the context is the  |
-|                                   | current account otherwise None    |
-+-----------------------------------+-----------------------------------+
-| Hash                              | Read                              |
-+-----------------------------------+-----------------------------------+
-| URef                              | See note below                    |
-+-----------------------------------+-----------------------------------+
-| Local                             | Read + Write + Add if the context |
-|                                   | seed used to construct the key    |
-|                                   | matches the current context       |
-+-----------------------------------+-----------------------------------+
-
-.. _global-state-urefs-permissions:
-
-Permissions for ``URef``\ s
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In the runtime, a ``URef`` carries its own permissions called ``AccessRights``.
-Additionally, the runtime tracks what ``AccessRights`` would be valid for each
-``URef`` to have in each context. As mentioned above, if a malicious contract
-attempts to use a ``URef`` with ``AccessRights`` that are not valid in its
-context, then the runtime will raise an error; this is what enforces the
-security properties of all keys. By default, in all contexts, all ``URef``\ s
-are invalid (both with any ``AccessRights``, or no ``AccessRights``); however, a
-``URef`` can be added to a context in the following ways:
-
--  it can exist in a set of “known” ``URef``\ s
--  it can be freshly created by the runtime via the ``new_uref`` function
--  for called contracts, it can be passed in by the caller via the arguments to
-   ``call_contract``
--  it can be returned back to the caller from ``call_contract`` via the ``ret``
-   function
-
-Note: that only valid ``URef``\ s may be added to the known ``URef``\ s or cross call
-boundaries; this means the system cannot be tricked into accepted a forged
-``URef`` by getting it through a contract or stashing it in the known ``URef``\ s.
-
-The ability to pass ``URef``\ s between contexts via ``call_contract`` / ``ret``, allows
-them to be used to share state among a fixed number of parties, while keeping it
-private from all others.
 
 .. _global-state-trie:
 

--- a/implementation/global-state.rst
+++ b/implementation/global-state.rst
@@ -1,4 +1,4 @@
-git l.. _global-state-head:
+.. _global-state-head:
 
 Global State
 ============

--- a/implementation/global-state.rst
+++ b/implementation/global-state.rst
@@ -11,11 +11,11 @@ Introduction
 The “global state” is the storage layer for the blockchain. All accounts,
 contracts, and any associated data they have are stored in the global state. Our
 global state has the semantics of a key-value store (with additional permissions
-logic, since not all users can access all values in the same way). Refer to :ref:`Keys and Permissions <serialization-standard-state-keys>` for further information on keys. Each block
+logic since not all users can access all values in the same way). Refer to :ref:`Keys and Permissions <serialization-standard-state-keys>` for further information on keys. Each block
 causes changes to this global state because of the execution of the deploys it
-contains. In order for validators to efficiently judge the correctness of these
+contains. For validators to efficiently judge the correctness of these
 changes, information about the new state needs to be communicated succinctly.
-Moreover, we need to be able to communicate pieces of the global state to users,
+Moreover, we need to communicate pieces of the global state to users
 while allowing them to verify the correctness of the parts they receive. For
 these reasons, the key-value store is implemented as a
 :ref:`Merkle trie <global-state-trie>`.
@@ -25,28 +25,21 @@ these reasons, the key-value store is implemented as a
 Merkle trie structure
 ------------------------------
 
-At a high level, a Merkle trie is a key-value store data structure
-which is able to be shared piece-wise in a verifiable way (via a construction
-called a Merkle proof). Each node is labelled by the hash of its data; for leaf
-nodes ---that is the data stored in that part of the tree, for other node types ---
-that is the data which references other nodes in the trie. Our implementation of
-the trie has radix of 256, this means each branch node can have up to 256
-children. This is convenient because it means a path through the tree can be
-described as an array of bytes, and thus serialization directly links a key with
-a path through the tree to its associated value.
+At a high level, a Merkle trie is a key-value store data structure that can be shared piece-wise in a verifiable way (via a construction
+called a Merkle proof). Each node is labeled by the hash of its data. Leaf nodes are labeled with the hash of their data. Non-leaf nodes are labeled with the hash of the labels of their child nodes.
+
+Our implementation of the trie has radix of 256, meaning each branch node can have up to 256 children. A path through the tree can be an array of bytes, and serialization directly links a key with a path through the tree as its associated value.
 
 Formally, a trie node is one of the following:
 
 -  a leaf, which includes a key and a value
 -  a branch, which has up to 256 ``blake2b256`` hashes, pointing to up to 256 other
-   nodes in the trie (recall each node is labelled by its hash)
+   nodes in the trie (recall each node is labeled by its hash)
 -  an extension node, which includes a byte array (called the affix) and a
    ``blake2b256`` hash pointing to another node in the trie
 
-The purpose of the extension node is to allow path compression. For example, if
-all keys for values in the trie used the same first four bytes, then it would be
-inefficient to need to traverse through four branch nodes where there is only
-one choice, and instead the root node of the trie could be an extension node with
+The purpose of the extension node is to allow path compression. Consider an example where all keys use the same first four bytes for values in the trie. In this case, it would be inefficient to traverse through four branch nodes where there is only
+one choice; instead, the root node of the trie could be an extension node with
 affix equal to those first four bytes and pointer to the first non-trivial
 branch node.
 
@@ -56,8 +49,7 @@ The rust implementation of our trie can be found on GitHub:
 -  `reading from the trie <https://github.com/CasperLabs/casper-node/blob/cb1d20ad1ea6e245cd8237f9406885a1e785c669/execution_engine/src/storage/trie_store/operations/mod.rs#L37>`_
 -  `writing to the trie <https://github.com/CasperLabs/casper-node/blob/cb1d20ad1ea6e245cd8237f9406885a1e785c669/execution_engine/src/storage/trie_store/operations/mod.rs#L638>`_
 
-Note: that conceptually, each block has its own trie because the state changes
+Note: Conceptually, each block has its trie because the state changes
 based on the deploys it contains. For this reason, our implementation has a
-notion of a ``TrieStore`` which allows us to look up the root node for each
+notion of a ``TrieStore``, which allows us to look up the root node for each
 trie.
-

--- a/implementation/global-state.rst
+++ b/implementation/global-state.rst
@@ -1,4 +1,4 @@
-.. _global-state-head:
+git l.. _global-state-head:
 
 Global State
 ============

--- a/implementation/index.rst
+++ b/implementation/index.rst
@@ -9,6 +9,7 @@ Design
    execution-semantics.rst
    accounts.rst
    block-structure.rst
+   uref.rst
    serialization-standard.rst
    tokens.rst
    appendix.rst

--- a/implementation/serialization-standard.rst
+++ b/implementation/serialization-standard.rst
@@ -2,7 +2,7 @@
 
 Serialization Standard
 ======================
-We provide a custom implementation to serialize data structures used by the Casper node to their byte representation. This document details how this custom serialization is implemented, allowing developers to build their own library that implements the custom serialization.
+We provide a custom implementation to serialize data structures used by the Casper node to their byte representation. This document details how this custom serialization is implemented, allowing developers to build a library that implements the custom serialization.
 
 
 .. _serialization-standard-block:
@@ -70,7 +70,7 @@ Note that ``EraEnd`` is an optional field. Thus the above scheme only applies if
 
 Body
 ~~~~
-The body portion of the block, is structurally defined as:
+The body portion of the block is structurally defined as:
 
 
 * ``proposer``: The PublicKey which proposed this block.
@@ -100,7 +100,7 @@ A deploy is structurally defined as follows:
 
 Deploy-Hash
 ~~~~~~~~~~~~
-The Deploy hash is a Digest over the contents of the Deploy header. The Deploy Hash serializes as the byte representation of the hash itself.
+The deploy hash is a digest over the contents of the deploy header. The deploy hash serializes as the byte representation of the hash itself.
 
 Deploy-Header
 ~~~~~~~~~~~~~
@@ -162,23 +162,29 @@ Payment and Session are both defined as ``ExecutableDeployItems``. ``ExecutableD
         },
     }
 
+
 - Module Bytes are serialized such that the first byte within the serialized buffer is ``0`` with the rest of the buffer containing the bytes present.
+    
     - ``ModuleBytes { module_bytes: "[72 bytes]", args: 434705a38470ec2b008bb693426f47f330802f3bd63588ee275e943407649d3bab1898897ab0400d7fa09fe02ab7b7e8ea443d28069ca557e206916515a7e21d15e5be5eb46235f5 }`` will serialize to
     - ``0x0048000000420481b0d5a665c8a7678398103d4333c684461a71e9ee2a13f6e859fb6cd419ed5f8876fc6c3e12dce4385acc777edf42dcf8d8d844bf6a704e5b2446750559911a4a328d649ddd48000000434705a38470ec2b008bb693426f47f330802f3bd63588ee275e943407649d3bab1898897ab0400d7fa09fe02ab7b7e8ea443d28069ca557e206916515a7e21d15e5be5eb46235f5``
 
-- StoredContractByHash serializes such that the first byte within the serialized buffer is 1u8. This is followed by the byte representation of the remain fields.
+- StoredContractByHash serializes such that the first byte within the serialized buffer is 1u8. This is followed by the byte representation of the remaining fields.
+    
     - ``StoredContractByHash { hash: c4c411864f7b717c27839e56f6f1ebe5da3f35ec0043f437324325d65a22afa4, entry_point: "pclphXwfYmCmdITj8hnh", args: d8b59728274edd2334ea328b3292ed15eaf9134f9a00dce31a87d9050570fb0267a4002c85f3a8384d2502733b2e46f44981df85fed5e4854200bbca313e3bca8d888a84a76a1c5b1b3d236a12401a2999d3cad003c9b9d98c92ab1850 }``
     - ``0x01c4c411864f7b717c27839e56f6f1ebe5da3f35ec0043f437324325d65a22afa41400000070636c7068587766596d436d6449546a38686e685d000000d8b59728274edd2334ea328b3292ed15eaf9134f9a00dce31a87d9050570fb0267a4002c85f3a8384d2502733b2e46f44981df85fed5e4854200bbca313e3bca8d888a84a76a1c5b1b3d236a12401a2999d3cad003c9b9d98c92ab1850``
 
-- StoredContractByName serializes such that the first byte within the serialized buffer is 2u8. This followed by the indiviual byte representation of the remaining fields.
+- StoredContractByName serializes such that the first byte within the serialized buffer is 2u8. This is followed by the individual byte representation of the remaining fields.
+    
     - ``StoredContractByName { name: "U5A74bSZH8abT8HqVaK9", entry_point: "gIetSxltnRDvMhWdxTqQ", args: 07beadc3da884faa17454a }``
     - ``0x0214000000553541373462535a483861625438487156614b39140000006749657453786c746e5244764d685764785471510b00000007beadc3da884faa17454a``
 
-- StoredVersionedContractByHash serializes such that the first byte within the serialized buffer is 3u8. However, the field version within the enum serializes as a Option CLValue, i.e if the value is None as shown in the example, it serializes to 0, else it serializes the inner u32 value which is described below.
+- StoredVersionedContractByHash serializes such that the first byte within the serialized buffer is 3u8. However, the field version within the enum serializes as an Option CLValue, i.e., if the value is None as shown in the example, it serializes to 0, else it serializes the inner u32 value, which is described below.
+    
     - ``StoredVersionedContractByHash { hash: b348fdd0d0b3f66468687df93141b5924f6bb957d5893c08b60d5a78d0b9a423, version: None, entry_point: "PsLz5c7JsqT8BK8ll0kF", args: 3d0d7f193f70740386cb78b383e2e30c4f976cf3fa834bafbda4ed9dbfeb52ce1777817e8ed8868cfac6462b7cd31028aa5a7a60066db35371a2f8 }``
     - ``0x03b348fdd0d0b3f66468687df93141b5924f6bb957d5893c08b60d5a78d0b9a423001400000050734c7a3563374a73715438424b386c6c306b463b0000003d0d7f193f70740386cb78b383e2e30c4f976cf3fa834bafbda4ed9dbfeb52ce1777817e8ed8868cfac6462b7cd31028aa5a7a60066db35371a2f8``
 
-- StoredVersionedContractByName serializes such that the first byte within the serialized buffer is 4u8. The name and entry_point are serialized as a String CLValue, with the Option version field serializing to 0 if the value is None, else it serializes the inner u32 value as described below.
+- StoredVersionedContractByName serializes such that the first byte within the serialized buffer is 4u8. The name and entry_point are serialized as a String CLValue, with the Option version field serializing to 0 if the value is None; else, it serializes the inner u32 value as described below.
+    
     - ``StoredVersionedContractByName { name: "lWJWKdZUEudSakJzw1tn", version: Some(1632552656), entry_point: "S1cXRT3E1jyFlWBAIVQ8", args: 9975e6957ea6b07176c7d8471478fb28df9f02a61689ef58234b1a3cffaebf9f303e3ef60ae0d8 }``
     - ``0x04140000006c574a574b645a5545756453616b4a7a7731746e01d0c64e61140000005331635852543345316a79466c57424149565138270000009975e6957ea6b07176c7d8471478fb28df9f02a61689ef58234b1a3cffaebf9f303e3ef60ae0d8``
 
@@ -270,7 +276,7 @@ The details of ``CLType`` serialization are in the following section. Using the 
 - accounts serialize in the same way as data with ``CLType`` equal to
   ``Tuple5(FixedList(U8, 32), Map(String, Key), URef, Map(FixedList(U8, 32), U8), Tuple2(U8, U8))``.
 
-Note: ``Tuple5`` is not a presently supported ``CLType``. However it is clear how to generalize the rules for ``Tuple1``, ``Tuple2``, ``Tuple3`` to any size tuple.
+Note: ``Tuple5`` is not a presently supported ``CLType``. However, it is clear how to generalize the rules for ``Tuple1``, ``Tuple2``, ``Tuple3`` to any size tuple.
 
 Note: links to further serialization examples and a reference implementation are found in :ref:`Appendix B <appendix-b>`.
 
@@ -459,20 +465,20 @@ Contracts are a special value type because they contain the on-chain logic of th
 -  a collection of named keys
 -  a protocol version
 
-The wasm module must contain a function named ``call`` which takes no arguments and returns no values. This is the main entry point into the contract. Moreover, the module may import any of the functions supported by the Casper runtime; a list of all supported functions can be found in :ref:`Appendix A <appendix-a>`.
+The wasm module must contain a function named ``call``, which takes no arguments and returns no values. This is the main entry point into the contract. Moreover, the module may import any of the functions supported by the Casper runtime; a list of all supported functions can be found in :ref:`Appendix A <appendix-a>`.
 
-Note: though the ``call`` function signature has no arguments and no return value, within the ``call`` function body the ``get_named_arg`` runtime function can be used to accept arguments (by ordinal), and the ``ret`` runtime function can be used to return a single ``CLValue`` to the caller.
+Note: though the ``call`` function signature has no arguments and no return value, within the ``call`` function body, the ``get_named_arg`` runtime function can be used to accept arguments (by ordinal), and the ``ret`` runtime function can be used to return a single ``CLValue`` to the caller.
 
 The named keys are used to give human-readable names to keys in the global state, which are essential to the contract. For example, the hash key of another contract it frequently calls may be stored under a meaningful name. It is also used to store the ``URef``\ s, which are known to the contract (see the section on Permissions for details).
 
-Each contract specifies the Casper protocol version that was active when the contract was written to global state.
+Each contract specifies the Casper protocol version that was active when the contract was written to the global state.
 
 .. _serialization-standard-state-keys:
 
 Keys
 ----
 
-In this chapter we describe what constitutes a “key”, the permissions model for the keys, and how they are serialized.
+In this chapter, we describe what constitutes a “key”, the permissions model for the keys, and how they are serialized.
 
 A *key* in the :ref:`Global State<global-state-intro>` is one of the following data types:
 
@@ -484,7 +490,7 @@ A *key* in the :ref:`Global State<global-state-intro>` is one of the following d
 -  32-byte Era information identifier
 -  32-byte purse balance identifier
 -  32-byte Auction bid identifier
--  32-byte Auction withdraw identifier
+-  32-byte Auction withdrawal identifier
 -  32-byte Era validator identifier
 
 .. _global-state-account-key:
@@ -494,7 +500,7 @@ Account identity key
 
 This key type is used specifically for accounts in the global state. All
 accounts in the system must be stored under an account identity key, and no
-other type. The 32-byte identifier which represents this key is derived from the
+other types. The 32-byte identifier which represents this key is derived from the
 ``blake2b256`` hash of the public key used to create the associated account (see
 :ref:`Accounts <accounts-associated-keys-weights>` for more information).
 
@@ -508,7 +514,7 @@ written under a hash key, that contract can never change. The 32-byte identifier
 representing this key is derived from the ``blake2b256`` hash of the deploy hash
 (see :ref:`block-structure-head` for more information) concatenated
 with a 4-byte sequential ID. The ID begins at zero for each deploy and
-increments by 1 each time a contract is stored. The purpose of this ID is to
+increments by one each time a contract is stored. The purpose of this ID is to
 allow each contract stored in the same deploy to have a unique key.
 
 .. _serialization-standard-uref:
@@ -526,7 +532,7 @@ Transfer Key
 ~~~~~~~~~~~~~
 
 This key type is used specifically for transfers in the global state. All
-transfers in the system must be stored under a transfer key, and no
+transfers in the system must be stored under a transfer key and no
 other type. The 32-byte identifier which represents this key is derived from the
 ``blake2b256`` hash of the transfer address associated with the given transfer
 
@@ -536,7 +542,7 @@ DeployInfo Key
 ~~~~~~~~~~~~~~~
 
 This key type is used specifically for storing information related to deploys in the global state.
-Information for the a given deploy is stored under this key only.
+Information for a given deploy is stored under this key only.
 The 32-byte identifier which represents this key is derived from the
 ``blake2b256`` hash of the deploy itself.
 
@@ -546,7 +552,7 @@ EraInfo Key
 ~~~~~~~~~~~~
 This key type is used specifically for storing information related to the ``Auction`` metadata for a particular era.
 The underlying data type stored under this is a vector of the allocation of seigniorage for that given era.
-The identifier for this key is a new type which wraps around the primitive ``u64`` data type and co-relates
+The identifier for this key is a new type that wraps around the primitive ``u64`` data type and co-relates
 to the era number when the auction information was stored.
 
 .. _serialization-standard-balance-key:
@@ -554,14 +560,14 @@ to the era number when the auction information was stored.
 Balance Key
 ~~~~~~~~
 This key type is used to store information related to the balance of a given purse. All purse balances are stored using this key.
-The 32-byte identifier which represents this key is derived from the Address of the URef which relates to the purse.
+The 32-byte identifier which represents this key is derived from the Address of the URef, which relates to the purse.
 
 .. _serialization-standard-bid-key:
 
 Bid Key
 ~~~~
 
-This key type is used specifically for storing information related auction bids in the global state.
+This key type is used specifically for storing information related to auction bids in the global state.
 Information for the bids is stored under this key only. The 32-byte identifier which represents this key is derived from the
 ``blake2b256`` hash of the public key used to create the associated account (see
 :ref:`Accounts <accounts-associated-keys-weights>` for more information).
@@ -571,8 +577,8 @@ Information for the bids is stored under this key only. The 32-byte identifier w
 Withdraw Key
 ~~~~~~~~~
 
-This key type is used specifically for storing information related auction withdraws in the global state.
-Information for the withdraws is stored under this key only. The 32-byte identifier which represents this key is derived from the
+This key type is used specifically for storing information related to auction withdraws in the global state.
+Information for the withdrawals is stored under this key only. The 32-byte identifier which represents this key is derived from the
 ``blake2b256`` hash of the public key used to create the associated account (see
 :ref:`Accounts <accounts-associated-keys-weights>` for more information).
 
@@ -580,7 +586,7 @@ Information for the withdraws is stored under this key only. The 32-byte identif
 
 EraValidators Key
 ~~~~~~~~~~~~~~~~~~~~~~
-This key type is used specifically for storing information related to the set validators for a given era within global state.
+This key type is used specifically for storing information related to the set validators for a given era within the global state.
 Information for validator sets for a given era is stored under this key only. The identifier for this key is a wrapper around
 the primitive ``u64`` which corresponds to the era number for a given validator set.
 
@@ -589,9 +595,9 @@ the primitive ``u64`` which corresponds to the era number for a given validator 
 Serialization for ``Key``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Given the different variants for the over-arching ``Key`` data-type, each of the different variants are serailized differently.
+Given the different variants for the over-arching ``Key`` data-type, each of the different variants is serialized differently.
 This section of this chapter details how the individual variants are serialized.
-The leading byte of the serialized buffer acts a tag indicating the serialized variant.
+The leading byte of the serialized buffer acts as a tag indicating the serialized variant.
 
 +--------------------+-------------------+
 | ``Key``            | Serialization Tag |
@@ -617,17 +623,15 @@ The leading byte of the serialized buffer acts a tag indicating the serialized v
 | ``EraValidators``  |                 9 |
 +--------------------+-------------------+
 
-
 - ``Account`` serializes as a 32 byte long buffer containing the byte representation of the underlying ``AccountHash``
 - ``Hash`` serializes as a 32 byte long buffer containing the byte representation of the underlying ``Hash`` itself.
-- ``URef`` is a tuple that contains the address of the URef and the access rights to that ``URef``. The serialized representation of the ``URef`` is 33 bytes long. The first 32 bytes are the byte representation of the ``URef`` address and the last byte contains the bits corresponding to the access rights of the ``URef``. Refer to the :ref:`CLValue<serialization-standard-values>` section of this chapter for details on how ``AccessRights`` are serialized.
+- ``URef`` is a tuple that contains the address of the URef and the access rights to that ``URef``. The serialized representation of the ``URef`` is 33 bytes long. The first 32 bytes are the byte representation of the ``URef`` address, and the last byte contains the bits corresponding to the access rights of the ``URef``. Refer to the :ref:`CLValue<serialization-standard-values>` section of this chapter for details on how ``AccessRights`` are serialized.
 - ``Transfer`` serializes as a 32 byte long buffer containing the byte representation of the hash of the transfer.
 - ``DeployInfo`` serializes as 32 byte long buffer containing the byte representation of the Deploy hash. See the Deploy section above for how Deploy hashes are serialized.
 - ``EraInfo`` serializes a ``u64`` primitive type by adding additional padding. The serialized buffer is 32 bytes long with the leading 24 bytes as 0 padding, and the following 8 bytes contain a Lower endian byte representation of ``u64``.
 - ``Balance`` serializes as 32 byte long buffer containing the byte representation of the URef address.
-- ``Bid`` and ``Withdraw`` both contain the ``AccountHash`` as their identifier, therefore they serialize in the same manner as the ``Account`` variant.
+- ``Bid`` and ``Withdraw`` both contain the ``AccountHash`` as their identifier; therefore, they serialize in the same manner as the ``Account`` variant.
 - ``EraValidators`` also uses the padded serialization in the same manner as ``EraInfo``.
-
 
 
 .. _serialization-standard-permissions:
@@ -635,10 +639,10 @@ The leading byte of the serialized buffer acts a tag indicating the serialized v
 Permissions
 -----------
 
-There are three types of actions which can be done on a value: read, write, add.
-The reason for add to be called out separately from write is to allow for
-commutativity checking. The available actions depends on the key type and the
-context. Some key types only allow controlled access by smart contracts via the contract api, and other key types refer to values produced and used by the system itself and are not accessible to smart contracts at all but can be read via off-chain queries.
+There are three types of actions that can be done on a value: read, write, add.
+The reason for *add* to be called out separately from *write* is to allow for
+commutativity checking. The available actions depend on the key type and the
+context. Some key types only allow controlled access by smart contracts via the contract API, and other key types refer to values produced and used by the system itself and are not accessible to smart contracts at all but can be read via off-chain queries.
 This is summarized in the table below:
 
 +-----------------------------------+-----------------------------------+

--- a/implementation/serialization-standard.rst
+++ b/implementation/serialization-standard.rst
@@ -594,7 +594,7 @@ Serialization for ``Key``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Given the different variants for the over-arching ``Key`` data-type, each of the different variants are serailized differently.
-This section of this chapter details how the individual variants are serialized. Each of the key variants are serialize the identifier.
+This section of this chapter details how the individual variants are serialized.
 The leading byte of the serialized buffer acts a tag indicating the serialized variant.
 
 +--------------------+-------------------+

--- a/implementation/serialization-standard.rst
+++ b/implementation/serialization-standard.rst
@@ -34,7 +34,7 @@ The header portion of a Block, structurally, is defined as follows:
 
 * ``parent_hash``: is the hash of the parent block
 * ``state_root_hash``: is the current State Root hash
-* ``body_hash``: the hash of the block body.
+* ``body_hash``: the hash of the block header.
 * ``random_bit``: is a boolean whose serialization is described below.
 * ``accumulated_seed``: A seed needed for initializing a future era.
 * ``era_end``: contains Equivocation and reward information to be included in the terminal finalized block.

--- a/implementation/serialization-standard.rst
+++ b/implementation/serialization-standard.rst
@@ -295,7 +295,7 @@ Note: links to further serialization examples and a reference implementation are
       U512, // unsigned 512-bit integer primitive
       Unit, // singleton value without additional semantics
       String, // e.g. "Hello, World!"
-      URef, // unforgable reference (see above)
+      URef, // unforgeable reference (see above)
       Key, // global state key (see above)
       Option(CLType), // optional value of the given type
       List(CLType), // list of values of the given type (e.g. Vec in rust)
@@ -478,7 +478,7 @@ A *key* in the :ref:`Global State<global-state-intro>` is one of the following d
 
 -  32-byte account identifier (called an “account identity key”)
 -  32-byte immutable contract identifier (called a “hash key”)
--  32-byte reference identifier (called an “unforgable reference”)
+-  32-byte reference identifier (called an “unforgeable reference”)
 -  32-byte transfer identifier
 -  32-byte deploy information identifier
 -  32-byte Era information identifier
@@ -513,11 +513,11 @@ allow each contract stored in the same deploy to have a unique key.
 
 .. _serialization-standard-uref:
 
-Unforgable Reference (``URef``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Unforgeable Reference (``URef``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``URef`` broadly speaking can be used to store values and manage permissions to interact with the value stored under the ``URef``. ``URef`` is a tuple which contains the address under which the values are stored and the Access rights to the ``URef``.
-Refer to the :ref:`Unforgable Reference<uref-head>` section for details on how ``URefs`` are managed.
+Refer to the :ref:`Unforgeable Reference<uref-head>` section for details on how ``URefs`` are managed.
 
 
 .. _serialization-standard-transfer-key:

--- a/implementation/tokens.rst
+++ b/implementation/tokens.rst
@@ -56,7 +56,7 @@ The ``AccessRights`` of the :ref:`URefs <global-state-urefs-permissions>`
 permissions model determine what actions are allowed to be performed
 when using a ``URef`` associated with a purse.
 
-As all ``URef``\ s are unforgable, the only way to interact with
+As all ``URef``\ s are unforgeable, the only way to interact with
 a purse is for a ``URef`` with appropriate ``AccessRights``
 to be given to the current context in a valid way (see ``URef`` permissions for details).
 

--- a/implementation/uref.rst
+++ b/implementation/uref.rst
@@ -1,0 +1,46 @@
+.. _uref-head:
+
+Unforgable Reference (URef)
+===========================
+
+This key type is used for storing any type of value except ``Account``.
+Additionally, ``URef``\ s used in contracts carry permission information with them
+to prevent unauthorized usage of the value stored under the key. This permission
+information is tracked by the runtime, meaning that if a malicious contract
+attempts to produce a ``URef`` with permissions that contract does not actually
+have, we say the contract has attempted to “forge” the unforgable reference, and
+the runtime will raise a forged ``URef`` error. Permissions for a ``URef`` can be
+given across contract calls, allowing data stored under a ``URef`` to be shared in
+a controlled way. The 32-byte identifier representing the key is generated
+randomly by the runtime (see :ref:`Execution Semantics <execution-semantics-urefs>` for
+for more information). The serialization for ``Access Rights`` that define the permissions for ``URefs`` is detailed in the :ref:`CLValues<serialization-standard-values>` section.
+
+
+.. _uref-permissions:
+
+Permissions for ``URef``\ s
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the runtime, a ``URef`` carries its own permissions called ``AccessRights``.
+Additionally, the runtime tracks what ``AccessRights`` would be valid for each
+``URef`` to have in each context. As mentioned above, if a malicious contract
+attempts to use a ``URef`` with ``AccessRights`` that are not valid in its
+context, then the runtime will raise an error; this is what enforces the
+security properties of all keys. By default, in all contexts, all ``URef``\ s
+are invalid (both with any ``AccessRights``, or no ``AccessRights``); however, a
+``URef`` can be added to a context in the following ways:
+
+-  it can exist in a set of “known” ``URef``\ s
+-  it can be freshly created by the runtime via the ``new_uref`` function
+-  for called contracts, it can be passed in by the caller via the arguments to
+   ``call_contract``
+-  it can be returned back to the caller from ``call_contract`` via the ``ret``
+   function
+
+Note: that only valid ``URef``\ s may be added to the known ``URef``\ s or cross call
+boundaries; this means the system cannot be tricked into accepted a forged
+``URef`` by getting it through a contract or stashing it in the known ``URef``\ s.
+
+The ability to pass ``URef``\ s between contexts via ``call_contract`` / ``ret``, allows
+them to be used to share state among a fixed number of parties, while keeping it
+private from all others.

--- a/implementation/uref.rst
+++ b/implementation/uref.rst
@@ -1,27 +1,25 @@
 .. _uref-head:
 
-Unforgable Reference (URef)
-===========================
+Unforgeable Reference (URef)
+============================
 
 This key type is used for storing any type of value except ``Account``.
-Additionally, ``URef``\ s used in contracts carry permission information with them
+Additionally, ``URef``\ s used in contracts carry permission information 
 to prevent unauthorized usage of the value stored under the key. This permission
 information is tracked by the runtime, meaning that if a malicious contract
-attempts to produce a ``URef`` with permissions that contract does not actually
-have, we say the contract has attempted to “forge” the unforgable reference, and
+attempts to produce a ``URef`` with permissions that the contract does not 
+have, we say the contract has attempted to “forge” the unforgeable reference, and
 the runtime will raise a forged ``URef`` error. Permissions for a ``URef`` can be
 given across contract calls, allowing data stored under a ``URef`` to be shared in
 a controlled way. The 32-byte identifier representing the key is generated
-randomly by the runtime (see :ref:`Execution Semantics <execution-semantics-urefs>` for
-for more information). The serialization for ``Access Rights`` that define the permissions for ``URefs`` is detailed in the :ref:`CLValues<serialization-standard-values>` section.
-
+randomly by the runtime (see :ref:`Execution Semantics <execution-semantics-urefs>` for more information). The serialization for ``Access Rights`` that define the permissions for ``URefs`` is detailed in the :ref:`CLValues<serialization-standard-values>` section.
 
 .. _uref-permissions:
 
 Permissions for ``URef``\ s
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In the runtime, a ``URef`` carries its own permissions called ``AccessRights``.
+In the runtime, a ``URef`` carries its permissions called ``AccessRights``.
 Additionally, the runtime tracks what ``AccessRights`` would be valid for each
 ``URef`` to have in each context. As mentioned above, if a malicious contract
 attempts to use a ``URef`` with ``AccessRights`` that are not valid in its
@@ -34,13 +32,13 @@ A ``URef`` can only be added to a context by the host logic, in the following wa
 -  it can be freshly created by the runtime via the ``new_uref`` function
 -  for called contracts, it can be passed in by the caller via the arguments to
    ``call_contract``
--  it can be returned back to the caller from ``call_contract`` via the ``ret``
+-  it can be returned to the caller from ``call_contract`` via the ``ret``
    function
 
 Note: that only valid ``URef``\ s may be added to the known ``URef``\ s or cross call
-boundaries; this means the system cannot be tricked into accepted a forged
+boundaries; this means the system cannot be tricked into accepting a forged
 ``URef`` by getting it through a contract or stashing it in the known ``URef``\ s.
 
 The ability to pass ``URef``\ s between contexts via ``call_contract`` / ``ret``, allows
-them to be used to share state among a fixed number of parties, while keeping it
+them to be used to share state among a fixed number of parties while keeping it
 private from all others.

--- a/implementation/uref.rst
+++ b/implementation/uref.rst
@@ -25,10 +25,10 @@ In the runtime, a ``URef`` carries its own permissions called ``AccessRights``.
 Additionally, the runtime tracks what ``AccessRights`` would be valid for each
 ``URef`` to have in each context. As mentioned above, if a malicious contract
 attempts to use a ``URef`` with ``AccessRights`` that are not valid in its
-context, then the runtime will raise an error; this is what enforces the
-security properties of all keys. By default, in all contexts, all ``URef``\ s
-are invalid (both with any ``AccessRights``, or no ``AccessRights``); however, a
-``URef`` can be added to a context in the following ways:
+context, then the runtime will raise an error; this is what enforces the security properties of all URefs used as a key.
+By default, in all contexts, all ``URef``\ s
+are assumed invalid regardless of declared AccessRights and are checked against the executing context for validity upon each attempted usage in session or smart contract logic.
+A ``URef`` can only be added to a context by the host logic, in the following ways:
 
 -  it can exist in a set of “known” ``URef``\ s
 -  it can be freshly created by the runtime via the ``new_uref`` function


### PR DESCRIPTION
REF: https://casperlabs.atlassian.net/browse/ECO-987

CHANGELOG:

- Moved the `Keys` section from `Global State` to `Serialization Standard`
- Updated `Keys` to the current model
- Updated `Block Structure` to reflect recent changes
- Created a new page dedicated to the explanation of `URefs`