### PR TITLE
ECO-993: add file structure in node setup

### DIFF
--- a/node-operator/setup.rst
+++ b/node-operator/setup.rst
@@ -27,12 +27,11 @@ The installation of ``casper-node-launcher``, ``casper-node``, and ``casper-clie
 
 Two main folders are relevant for our software: ``/etc/casper`` and ``/var/lib/casper``.
 
-Also, the default location for executables from the Debian package install is ``/usr/bin``.
-
 The following is the state of the filesystem after installing the ``casper-client`` and ``casper-node-launcher`` Debian packages, and also after running the script */etc/casper/pull_casper_node_version.sh*.
 
 ``/usr/bin``
 ~~~~~~~~~~~~~
+The default location for executables from the Debian package install is ``/usr/bin``.
 
 * ``casper-client`` - A client for interacting with the Casper network
 * ``casper-node-launcher`` - The launcher application which starts the ``casper-node`` as a child process

--- a/node-operator/setup.rst
+++ b/node-operator/setup.rst
@@ -6,51 +6,93 @@ Casper Node Launcher
 --------------------
 
 The node software is run from the ``casper-node-launcher`` package. This can be installed with a Debian package which also
-creates the casper user, creates directory structures and sets up a systemd unit and logrotate.
+creates the Casper user, creates directory structures and sets up a *systemd* unit and *logrotate*.
 
 The casper-node-launcher Debian package can be obtained from https://bintray.com/casperlabs/debian/casper-node-launcher.
 
-This can also be build from source from https://github.com/CasperLabs/casper-node-launcher.  However, all of the setup
-and pull of casper-node releases will be manual.
+You can also build from source: https://github.com/CasperLabs/casper-node-launcher. However, all of the setup and pull of casper-node releases will be manual.
 
 File Locations
 ^^^^^^^^^^^^^^
 
-This will describe the locations crated by the casper-node-launcher Debian install or needed for running casper-node versions
-and performing upgrades.
+This section describes the directories and files the ``casper-node-launcher`` Debian install creates, needed for running ``casper-node`` versions and performing upgrades.
 
-A ``casper`` user and ``casper`` group is created during install and used to run the software.
+A *casper* user and *casper* group is created during install and used to run the software.
 
-Each version of the casper-node install is located based on the semantic version with underscores.  For example: a version
-of ``1.0.3`` would be represented by a directory named ``1_0_3``.  This will apply to both binary and configuration file
-locations.  We will represent this with ``[m_n_p]`` below, representing for major, minor, patch of semantic version.
+Each version of the ``casper-node`` install is located based on the semantic version with underscores. For example, version *1.0.3* would be represented by a directory named ``1_0_3``. This convention applies to both binary and configuration file locations. We will represent versioning with ``[m_n_p]`` below, representing the major, minor, patch of a semantic version.
 
-Note: multiple version folders will exist on a system when upgrades are setup to happen.
+**Note**: multiple versioned folders will exist on a system when upgrades are setup.
 
-The casper-node-launcher is installed in ``/usr/bin/casper-node-launcher``
-This is the launcher application which will start casper-node as a child process.
+The installation of ``casper-node-launcher``, ``casper-node``, and ``casper-client`` software is relatively simple, but the process accomplishes many things behind the scenes. This section describes the installation process and where the files are stored.
 
-``/etc/casper`` is the default location for configuration files.  This can be overwritten with the ``CASPER_CONFIG_DIR``
-environment variable.  The paths below assume the default of ``/etc/casper``.
+Two main folders are relevant for our software: ``/etc/casper`` and ``/var/lib/casper``.
 
-``/etc/casper/casper-node-launcher.state.toml`` is the launcher’s cached state.
+Also, the default location for executables from the Debian package install is ``/usr/bin``.
 
-``/etc/casper/[m_n_p]`` stores config files for ``casper-node`` of the associated version.  This will hold ``config.toml``,
-``chainspec.toml``, and ``accounts.csv`` (optional after first version).
+The following is the state of the filesystem after installing the ``casper-client`` and ``casper-node-launcher`` Debian packages, and also after running the script */etc/casper/pull_casper_node_version.sh*.
 
-``/etc/casper/validator_keys/`` is the default location for node keys. A ``README.md`` in this directory indicates how
-to create keys using the ``casper-client``.
+``/usr/bin``
+~~~~~~~~~~~~~
 
-``/var/lib/casper`` is the location for larger and variable data for the casper-node.
+* ``casper-client`` - A client for interacting with the Casper network
+* ``casper-node-launcher`` - The launcher application which starts the ``casper-node`` as a child process
 
-``/var/lib/casper/casper-node`` is the location for where casper-node stores local .lmdb files.
+``/etc/casper``
+~~~~~~~~~~~~~~~
+This is the default location for configuration files. It can be overwritten with the ``CASPER_CONFIG_DIR`` environment variable. The paths in this document assume the default configuration file location of ``/etc/casper``. The data is organized as follows:
 
-``/var/lib/casper/bin`` is the location for storing the versions of ``casper-node`` executables.
-This location can be overwritten with the ``CASPER_BIN_DIR`` environment variable.
-The path below assume the default of ``/var/lib/casper/bin``
+* **delete_local_db.sh** - Removes `*.lmdb*` from ``/var/lib/casper/casper-node``
+    
+* **pull_casper_node_version.sh** <protocol_version> <network_name> - Pulls ``bin.tar.gz`` and ``config.tar.gz`` from `genesis.casperlabs.io <http://genesis.casperlabs.io/>`_ for a protocol package; decompresses them into ``/var/lib/bin/<protocol_version>`` and ``/etc/casper/<protocol_version>``, and removes the *\*.tar.gz* files
 
-``/var/lib/casper/bin/[m_n_p]/casper-node`` is where the given version of casper-node executable lives and is run from
-the casper-node-launcher.
+* **config_from_example.sh** <protocol_version> - Gets external an IP to replace and create the *config.toml* from *config-example.toml*
+
+* **casper-node-launcher-state.toml** - This is the local state for the ``casper-node-launcher`` and it is created during the first run
+
+* ``validator_keys`` - The default location for node keys.
+
+    * **README.md** - Instructions on how to create validator keys using the ``casper-client``
+    * **secret_key.pem** - ``casper-client keygen`` creates this file or it is manually copied here
+    * **public_key.pem** - ``casper-client keygen`` creates this file or it is manually copied here
+    * **public_key_hex** - ``casper-client keygen`` creates this file or it is manually copied here
+
+* ``1_0_0`` - created with *pull_casper_node_version.sh 1_0_0 <network_name>* for genesis files
+
+    * **accounts.toml** - Contains the genesis validators and delegators
+    * **chainspec.toml** - Contains the genesis state with the *activation_point* as a timestamp
+    * **config-example.toml** - Example for creating a *config.toml* file
+    * **config.toml** - Created by a node operator manually or by running *config_from_example.sh 1_0_0*
+
+* ``m_n_p`` - *0* to *N* upgrade packages
+
+    * **chainspec.toml** - Contains the *activation_point* as the Era ID int
+    * **config-example.toml** - Example for creating a *config.toml* file
+    * **config.toml** - Created by a node operator manually or by running *config_from_example.sh <protocol_version>*
+
+``/var/lib/casper``
+~~~~~~~~~~~~~~~~~~~
+This is the location for larger and variable data for the ``casper-node``, organized in the following directories and files:
+
+    * ``bin`` - The location for storing the versions of ``casper-node`` executables. This location can be overwritten with the ``CASPER_BIN_DIR`` environment variable. The paths in this document assume the default of ``/var/lib/casper/bin``.
+  
+        * ``1_0_0`` - Created with *pull_casper_node_version.sh 1_0_0 <network_name>* for binaries
+  
+            * ``casper-node`` - Defaults to the Ubuntu 18.04 compatible binary
+            * **README.md** - Information about the repository location and the Git hash used for compilation to allow a rebuild on other platforms
+  
+        * ``m_n_p`` - *0* to *N* upgrade packages for binaries using *pull_casper_node_version.sh 1_0_0 <network_name>* 
+  
+            * ``casper-node`` -  This is where the given version of the ``casper-node`` executable lives and is run from the ``casper-node-launcher``.
+            * **README.md**
+
+    * ``casper-node`` - Local data store and the largest user of disc space 
+  
+        * **data.lmdb** - Global state of the chain
+        * **data.lmbd-lock**
+        * **storage.lmdb** - Blocks, deploys, and everything else
+        * **storage.lmdb-lock**
+        * **unit_\*** - The node creates one of these files per era
+
 
 Upgrade Operation
 ^^^^^^^^^^^^^^^^^
@@ -78,7 +120,7 @@ Included with ``casper-node-launcher`` debian package are two scripts to help wi
 
 ``/etc/casper/pull_casper_node_version.sh`` will pull ``bin.tar.gz`` and ``config.tar.gz`` from genesis.casperlabs.io.
 
-This is invoked with the release version in undrescore format such as:
+This is invoked with the release version in underscore format such as:
 
 .. code-block:: bash
 
@@ -101,7 +143,7 @@ the correct version using ``sudo apt install``.
 Create Keys
 ^^^^^^^^^^^
 
-The Rust client generates keys via the ``keygen`` command.  The process generates 2 pem files and 1 text file.
+The Rust client generates keys via the ``keygen`` command.  The process generates 2 *pem* files and 1 *text* file.
 To learn about options for generating keys, include ``--help`` when running the ``keygen`` command.
 
 .. code-block:: bash
@@ -109,7 +151,7 @@ To learn about options for generating keys, include ``--help`` when running the 
    sudo casper-client keygen /etc/casper/validator_keys
 
 More about keys and key generation can be found in ``/etc/casper/validator_keys/README.md`` if ``casper-node-lancher``
-was installed from the debian package.
+was installed from the Debian package.
 
 Config File
 -----------
@@ -123,7 +165,7 @@ Below are some fields you may find in the ``config.toml`` that you may want or n
 Trusted Hash for Synchronizing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Casper network is a permissionless, proof of stake network - which implies that validators can come and go from the network.  The implication is that, after a point in time, historical data could have less security if it is retrieved from ‘any node’ on the network.  Therefore, the process for joining the network has to be from a trusted source, a bonded validator.  The system will start from the hash from a recent block and then work backwards from that block to obtain the deploys and finalized blocks from the linear block store.  Here is the process to get the trusted hash:
+The Casper network is a permissionless, proof of stake network - which implies that validators can come and go from the network.  The implication is that, after a point in time, historical data could have less security if it is retrieved from ‘any node’ on the network.  Therefore, joining the network has to be from a trusted source, a bonded validator.  The system will start from the hash from a recent block and then work backward from that block to obtain the deploys and finalized blocks from the linear block store.  Here is the process to get the trusted hash:
 
 * Find a list of trusted validators.  
 * Query the status endpoint of a trusted validator ( http://[validator_id]:8888/status )
@@ -141,7 +183,7 @@ Networking & Gossiping
 The node requires a publicly accessible IP address.  We do not recommend NAT at this time. Specify the public IP address of the node.
 If you use the ``config_from_example.sh`` external services are called to find your IP and this is inserted into the created ``config.toml``.
 
-Default values are specified in the file, if you want to change them:
+Default values are specified in the file if you want to change them:
 
 * Specify the port that will be used for status  & deploys
 * Specify the port used for networking 


### PR DESCRIPTION
Changes:

1. Moved the content from https://casperlabs.atlassian.net/wiki/spaces/REL/pages/1237843969/Casper+Node+Files to the node-operator/setup.rst file.
2. Merged the content from the confluence page with what was already in the node-operator/setup.rst file.
3. Checked the file for grammar and spelling.
4. Replaced x_y_z with m_n_p.

For naming directories and scripts, I followed this convention:
- bolded file names when introducing them in a list
- italicized file names in other areas of the document
- used `` for directory names everywhere

This is only part 1 of [Jira card 993](https://casperlabs.atlassian.net/browse/ECO-993). I have to work on another section to complete the story.

Here is a pdf version of the new file: [Basic Node Setup.pdf](https://github.com/CasperLabs/docs/files/6173561/Basic.Node.Setup.pdf).
