### PR TITLE
Removing protobuf from documentation

### DIFF
--- a/dapp-dev-guide/setup-of-rust-contract-sdk.rst
+++ b/dapp-dev-guide/setup-of-rust-contract-sdk.rst
@@ -75,32 +75,6 @@ CMake is a popular build tool that we will utilize, and you may very well have i
    CMake suite maintained and supported by Kitware (kitware.com/cmake).
 
 
-**2. Google Protobuf Compiler**
-
-Next, we need to install ``protoc``, which is used for serializing structured data. Installation on MacOS or Linux is shown below, but other operating systems should refer to the documentation: https://google.github.io/proto-lens/installing-protoc.html.
-
-
-Linux with :code:`apt`: 
-
-.. code::
-
-   sudo apt install protobuf-compiler
-
-
-MacOS with :code:`brew`:
-
-.. code::
-
-   brew install protobuf
-
-Once the Google protobuf compiler is installed, you can check your version:
-
-.. code::
-
-   $ protoc --version
-   libprotoc 3.14.0
-
-
 Development Environment Setup
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/implementation/block-structure.rst
+++ b/implementation/block-structure.rst
@@ -10,15 +10,6 @@ Introduction
 
 A *block* is the primary data structure by which information about the state of the CasperLabs system is communicated between nodes of the network. We briefly describe here the format of this data structure.
 
-.. _block-structure-proto:
-
-Protobuf definition
--------------------
-
-Messages between nodes are communicated using `Google’s protocol
-buffers <https://developers.google.com/protocol-buffers/>`__. The complete definition of a block in this format can be `found on
-GitHub <https://github.com/CasperLabs/CasperLabs/blob/c78e35f4d8f0f7fd9b8cf45a4b17a630ae6ab18f/protobuf/io/casperlabs/casper/consensus/consensus.proto#L111>`__ ; the description here is only meant to provide an overview of the block format; the protobuf definition is authoritative.
-
 .. _block-structure-data:
 
 Data fields
@@ -36,7 +27,7 @@ Each of these are detailed in the subsequent sections.
 ``block_hash``
 ~~~~~~~~~~~~~~
 
-The ``block_hash`` is the ``blake2b256`` hash of the header (serialized according to the protobuf specification).
+The ``block_hash`` is the ``blake2b256`` hash of the header.
 
 Header
 ~~~~~~
@@ -60,8 +51,7 @@ The block header contains the following fields:
       block (``post_state_hash``)
    -  the list of currently bonded validators, and their stakes
 
--  the ``blake2b256`` hash of the body of the block (serialized according to the
-   protobuf specification)
+-  the ``blake2b256`` hash of the body of the block
 -  the time the block was created
 -  the protocol version the block was executed with
 -  the number of deploys in the block


### PR DESCRIPTION
In this PR, I propose removing protobuf from the documentation. [PR 147](https://github.com/CasperLabs/docs/pull/147) is already taking care of this obsolete link in block-structure.rst (this is why I didn't change it): https://github.com/CasperLabs/CasperLabs/blob/c78e35f4d8f0f7fd9b8cf45a4b17a630ae6ab18f/protobuf/io/casperlabs/casper/consensus/consensus.proto#L24. 